### PR TITLE
Cache feeds for 1 hour

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/core.memoize "0.5.8"]
                  [cheshire "5.4.0"]
                  [compojure "1.3.2"]
                  [ring/ring-defaults "0.1.2"]

--- a/src/clojars_json/core.clj
+++ b/src/clojars_json/core.clj
@@ -1,5 +1,6 @@
 (ns clojars-json.core
   (:require [cheshire.core :as json]
+            [clojure.core.memoize :as memo]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [compojure.core :refer :all]
@@ -39,11 +40,15 @@
 (def package-url "https://clojars.org/repo/all-jars.clj.gz")
 (def feed-url "http://clojars.org/repo/feed.clj.gz")
 
-(defn process-url
+(defn process-url*
   ([f url]
-     (process-url f url {}))
+     (process-url* f url {}))
   ([f url options]
      (f (fetch-url url options))))
+
+(def process-url
+  (memo/ttl process-url*
+    :ttl/threshold (* 60 60 1000))) ;; one hour
 
 (defn parse-feed [data]
   (kv-to-hash


### PR DESCRIPTION
This uses core.memoize instead of using a memcache provided by
heroku. It's simpler, but means each dyno has its own cache, and will
lose that cache if spun down.

This depends on #13, possibly.
